### PR TITLE
Fixed typographical error, changed auxilary to auxiliary in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Changelog - Kernel - 3.0.8-alok+
 - Added USB SCSI adapter - I have lots of SCSI harddisk lying around, and USB adapter for them, but they seemed not to work earlier.
 - Added Pegasus network support
 - FB set - all options enabled - you should have better control for fb setting.
-- Added auxilary Video - If you have a USB LED,LCD screen lying around - try connecting to PIcUntu, should work. (in addition to HDMI) - required for in-car applications.
+- Added auxiliary Video - If you have a USB LED,LCD screen lying around - try connecting to PIcUntu, should work. (in addition to HDMI) - required for in-car applications.
 - Modules for USB Printer - now you should be able to connect USB printers to PicUntu
 - Serial Modem drivers - Qualcom, NAVMAN,
 - Added Joliet/UDF support - You should be able to connect USB CDROM


### PR DESCRIPTION
aloksinha2001, I've corrected a typographical error in the documentation of the [picuntu-3.0.8-alok](https://github.com/aloksinha2001/picuntu-3.0.8-alok) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
